### PR TITLE
Fix uniqueId is required for correct behavior

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1016,7 +1016,7 @@ class QiscusSDK {
       id: Math.round(Math.random() * 10e6),
       type: type || 'text',
       timestamp: format(new Date()),
-      unique_id: String(uniqueId),
+      unique_id: uniqueId ? String(uniqueId) : null,
       payload: tryCatch(
         () => JSON.parse(payload),
         payload,


### PR DESCRIPTION
Setelah update fix error kalau unique_id bukan string, perintah `String(uniqueId)` menyebabkan `null` menjadi `"null"` sehingga behavior comment jadi berubah, komen yang kita kirim tidak masuk ke list komen.