### PR TITLE
fix(README): fixed install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ This library contains core functionalities needed to create a chat application u
 ## Installing
 
 ```
-$ npm i qiscus-sdk-core
+$ npm i qiscus-sdk-javascript
 // or if you're using yarn
-$ yarn add qiscus-sdk-core
+$ yarn add qiscus-sdk-javascript
 ```
 
 then you need to import this library into your application.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ yarn add qiscus-sdk-javascript
 then you need to import this library into your application.
 
 ```
-import QiscusSDK from 'qiscus-sdk-core';
+import QiscusSDK from 'qiscus-sdk-javascript';
 
 const qiscus = new QiscusSDK();
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Qiscus Web SDK Core
 
-This library contains core functionalities needed to create a chat application using qiscus. 
+This library contains core functionalities needed to create a chat application using qiscus.
+
+Check out the V3 migration guide with Typescript details here: [V3 Migration Guide](https://github.com/qiscus/qiscus-sdk-web-core/blob/v3/MIGRATION_GUIDE.md)
 
 ## Installing
 


### PR DESCRIPTION
Fixed the install command, as v3 is available under a different npm name.

We are using v3 for our new projects now.

If it's fine for you, please merge.

PS: Not sure if "javascript" is the right name for it, as it comes with typescript.
Is there a plan to deprecate javascript?