### PR TITLE
fix: support device_platform param for FCM web registration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qiscus-sdk-core",
-  "version": "2.16.4",
+  "version": "2.16.5",
   "description": "Qiscus Web SDK Core",
   "license": "MIT",
   "main": "lib/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -1291,23 +1291,23 @@ class QiscusSDK {
     return this.loadComments(this.selected.id, options)
   }
 
-  async registerDeviceToken(token, isDevelopment = false) {
+  async registerDeviceToken(token, isDevelopment = false, devicePlatform = 'rn') {
     const res = await this.HTTPAdapter.post(
       'api/v2/sdk/set_user_device_token',
       {
         device_token: token,
-        device_platform: 'rn',
+        device_platform: devicePlatform,
         is_development: isDevelopment,
       }
     )
     return res.body.results
   }
-  async removeDeviceToken(token, isDevelopment = false) {
+  async removeDeviceToken(token, isDevelopment = false, devicePlatform = 'rn') {
     const res = await this.HTTPAdapter.post(
       'api/v2/sdk/remove_user_device_token',
       {
         device_token: token,
-        device_platform: 'rn',
+        device_platform: devicePlatform,
         is_development: isDevelopment,
       }
     )


### PR DESCRIPTION
## Summary
- `registerDeviceToken` / `removeDeviceToken` selalu mengirim `device_platform: 'rn'` hardcoded ke `/set_user_device_token` dan `/remove_user_device_token`, sehingga registrasi FCM Web tidak bisa dibedakan dari RN di backend.
- Tambah parameter opsional `devicePlatform` (default `'rn'`) di kedua method, sehingga caller bisa pass `'web'` secara eksplisit untuk FCM Web tanpa mengubah behavior existing RN consumer.
- Bump version `2.16.4` → `2.16.5`.

## Test plan
- [x] `registerDeviceToken(token, false)` tanpa param ke-3 tetap kirim `device_platform: 'rn'` (no breaking change untuk RN)
- [x] `registerDeviceToken(token, false, 'web')` mengirim `device_platform: 'web'`
- [x] `removeDeviceToken(token, false, 'web')` mengirim `device_platform: 'web'`
- [x] Regression check: flow register/unregister device token RN existing tidak berubah
